### PR TITLE
[SC-324] Add logic to retry request for creation a transaction.

### DIFF
--- a/didsdk/did_service.py
+++ b/didsdk/did_service.py
@@ -140,14 +140,6 @@ class DidService:
 
         return self.read_document(did)
 
-    def get_did(self, address: str) -> str:
-        """Get the id of document from the did score.
-
-        :param address: the address of wallet is used for transaction.
-        :return: the id of document.
-        """
-        return self._did_score.get_did(address)
-
     def get_public_key(self, did: str, key_id: str) -> PublicKey:
         """Get a publicKey that matches the id of DID document and the id of publicKey.
 

--- a/didsdk/did_service.py
+++ b/didsdk/did_service.py
@@ -1,11 +1,13 @@
 import asyncio
 import json
+from typing import Union
+
 from coincurve import PublicKey
 from iconsdk.exception import JSONRPCException
 from iconsdk.icon_service import IconService
 from iconsdk.signed_transaction import SignedTransaction, Transaction
 from iconsdk.wallet.wallet import KeyWallet, Wallet
-from typing import Union
+from yirgachefe import logger
 
 from didsdk.document.document import Document
 from didsdk.exceptions import TransactionException, ResolveException, DocumentException
@@ -57,17 +59,22 @@ class DidService:
         :return:
         """
         response = None
-        tx_result = None
-        while response is None:
-            # TODO: retry logic
-            await asyncio.sleep(5)
+        retry_times = 5
+        while response is None and retry_times > 0:
             try:
                 tx_result = self._iconservice.get_transaction_result(tx_hash)
+                if not tx_result:
+                    raise JSONRPCException('transaction result is None.')
             except JSONRPCException as e:
-                if 'Pending transaction' not in e.message['message']:
+                logger.debug(f'{e}')
+
+                if retry_times == 0:
                     raise TransactionException(e)
 
-            if not tx_result:
+                retry_times -= 1
+                logger.debug(f'Remain to retry request for getting transaction result: {retry_times}')
+
+                await asyncio.sleep(2)
                 continue
 
             return tx_result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,8 +235,8 @@ def did_service_local() -> DidService:
 @pytest.fixture
 def did_service_testnet() -> DidService:
     return DidService(IconServiceFactory.create_testnet(),
-                      network_id=3,
-                      score_address='cxa18595c0b6b9c99f5ac5b6f12e136d9d2f221f4c')
+                      network_id=2,
+                      score_address='cxdd0cb8465b15e2971272c1ecf05691198552f770')
 
 
 @pytest.fixture

--- a/tests/unit/test_did_service.py
+++ b/tests/unit/test_did_service.py
@@ -1,7 +1,9 @@
 import os
+from pathlib import Path
+
 import pytest
 from iconsdk.wallet.wallet import KeyWallet
-from pathlib import Path
+from yirgachefe import logger
 
 from didsdk.core.algorithm_provider import AlgorithmType, AlgorithmProvider
 from didsdk.core.did_key_holder import DidKeyHolder
@@ -12,7 +14,6 @@ from didsdk.document.encoding import EncodeType
 from didsdk.exceptions import DocumentException
 from didsdk.jwt.jwt import Jwt
 from didsdk.score.did_score_parameter import DidScoreParameter
-from yirgachefe import logger
 
 
 class TestDidService:
@@ -81,17 +82,6 @@ class TestDidService:
         logger.debug(f"signed jwt: {signed_jwt}")
         logger.debug(f"document: {document}")
         logger.debug(f"document json: {document.serialize()}")
-
-    def test_get_did(self, did_service_testnet: DidService,
-                     test_wallet_keys, key_holder_from_key_store_file: DidKeyHolder):
-        # GIVEN a wallet and a did key holder
-        wallet = KeyWallet.load(bytes.fromhex(test_wallet_keys['private']))
-
-        # WHEN try to get did
-        did = did_service_testnet.get_did(wallet.get_address())
-
-        # THEN success to get the did from the wallet.
-        assert did == key_holder_from_key_store_file.did
 
     def test_get_public_key(self, did_service_testnet: DidService, key_holder_from_key_store_file: DidKeyHolder):
         # GIVEN a key provider

--- a/tests/utils/icon_service_factory.py
+++ b/tests/utils/icon_service_factory.py
@@ -5,7 +5,7 @@ from iconsdk.providers.http_provider import HTTPProvider
 
 class IconServiceFactory:
     LOCAL_BASE_DOMAIN = "http://127.0.0.1:9000"
-    TESTNET_BASE_DOMAIN = "https://bicon.net.solidwallet.io"
+    TESTNET_BASE_DOMAIN = "https://lisbon.net.solidwallet.io"
     VERSION = 3
 
     @staticmethod


### PR DESCRIPTION
[SC-324] Add logic to retry request for creation a transaction. 
 - Edit testnet configurations for lisbon.

[SC-324] Remove deprecated API. 
 - Remove `get_did` method by address, that's not supported upper than version 2.0.

[SC-324]: https://icon-project.atlassian.net/browse/SC-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SC-324]: https://icon-project.atlassian.net/browse/SC-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ